### PR TITLE
Fix editor installation issue

### DIFF
--- a/lib/installation.js
+++ b/lib/installation.js
@@ -6,9 +6,8 @@ const { execSync } = require('child_process')
 const rimraf = require('rimraf')
 const pathExists = require('path-exists')
 
-const {
-  git
-} = app
+const simpleGit = require('simple-git')
+const git = simpleGit()
 
 const installationLogger = logger.create({ name: 'Installation' })
 
@@ -16,13 +15,13 @@ installationLogger.log('Installation is awake')
 
 async function installEditor () {
   if (!pathExists.sync(app.paths.editor)) {
+    installationLogger.log(`Installing editor to ${app.paths.editor}`)
     try {
-      await git.clone({
-        dir: app.paths.editor,
-        url: 'https://github.com/ministryofjustice/fb-editor-node',
-        singleBranch: true,
-        depth: 1
-      })
+      await git.clone(
+        'https://github.com/ministryofjustice/fb-editor-node',
+        app.paths.editor,
+        ['--depth', '1']
+      )
     } catch ({ message }) {
       installationLogger.error(message)
     }
@@ -45,13 +44,13 @@ async function updateEditor () {
 
 async function installNVS () {
   if (!pathExists.sync(app.paths.nvs)) {
+    installationLogger.log(`Installing nvs to ${app.paths.nvs}`)
     try {
-      await git.clone({
-        dir: app.paths.nvs,
-        url: 'https://github.com/jasongin/nvs',
-        singleBranch: true,
-        depth: 1
-      })
+      await git.clone(
+        'https://github.com/jasongin/nvs',
+        app.paths.nvs,
+        ['--depth', '1']
+      )
     } catch ({ message }) {
       installationLogger.error(message)
     }
@@ -66,10 +65,12 @@ async function reinstallEditor () {
 
 async function removeDependencies () {
   await app.displayNotification('Removing NVS ...')
+  installationLogger.log(`Removing nvs from ${app.paths.nvs}`)
   rimraf.sync(app.paths.nvs)
   await app.displayNotification('... Done')
 
   await app.displayNotification('Removing Editor ...')
+  installationLogger.log(`Removing editor from ${app.paths.editor}`)
   rimraf.sync(app.paths.editor)
   await app.displayNotification('... Done')
 }

--- a/lib/installation.js
+++ b/lib/installation.js
@@ -28,20 +28,6 @@ async function installEditor () {
   }
 }
 
-async function updateEditor () {
-  if (pathExists.sync(app.paths.editor)) {
-    try {
-      await git.pull({
-        dir: app.paths.editor,
-        ref: 'master',
-        singleBranch: true
-      })
-    } catch ({ message }) {
-      installationLogger.error(message)
-    }
-  }
-}
-
 async function installNVS () {
   if (!pathExists.sync(app.paths.nvs)) {
     installationLogger.log(`Installing nvs to ${app.paths.nvs}`)
@@ -55,12 +41,6 @@ async function installNVS () {
       installationLogger.error(message)
     }
   }
-}
-
-async function reinstallEditor () {
-  await removeDependencies()
-
-  await installDependencies()
 }
 
 async function removeDependencies () {
@@ -104,25 +84,18 @@ function installEditorDependencies () {
 ipcRenderer.answerMain('update-editor', async () => {
   await app.displayNotification('Starting Editor update ...', { phase: 'Update Editor' })
 
-  await updateEditor()
+  await removeDependencies()
 
   await app.displayNotification('Installing dependencies ...', { phase: 'Update Editor' })
+  await installDependencies()
 
+  await app.displayNotification('Installing editor dependencies ...', { phase: 'Update Editor' })
   installEditorDependencies()
 
-  await app.displayNotification('Editor update finished', { dismiss: true })
-})
+  await app.displayNotification('Editor update finished. Restarting', { dismiss: true })
 
-ipcRenderer.answerMain('reinstall-editor', async () => {
-  await app.displayNotification('Starting Editor re-installation ...', { phase: 'Re-install Editor' })
-
-  await reinstallEditor()
-
-  await app.displayNotification('Installing dependencies ...', { phase: 'Re-install Editor' })
-
-  installEditorDependencies()
-
-  await app.displayNotification('Editor re-installation finished', { dismiss: true })
+  app.relaunch(5)
+  app.exit()
 })
 
 ipcRenderer.answerMain('install-editor', async () => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -248,8 +248,6 @@ async function executeInstallation (installation) {
 
 const updateEditor = () => executeInstallation('update-editor')
 
-const reinstallEditor = () => executeInstallation('reinstall-editor')
-
 const installEditor = () => executeInstallation('install-editor')
 
 const installEditorDependencies = () => executeInstallation('install-editor-dependencies')
@@ -274,7 +272,6 @@ module.exports = {
   dismissNotification,
   executeInstallation,
   updateEditor,
-  reinstallEditor,
   installEditor,
   installEditorDependencies
 }

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -47,8 +47,6 @@ function hideHasTokenFile () {
 
 const updateEditor = () => ipcRenderer.callMain('update-editor')
 
-const reinstallEditor = () => ipcRenderer.callMain('reinstall-editor')
-
 const getFieldNames = () => (
   Array
     .from(document.querySelectorAll('section#git-user input.govuk-input'))
@@ -105,12 +103,6 @@ async function onClickUpdateEditor (event) {
   await updateEditor()
 }
 
-async function onClickReinstallEditor (event) {
-  event.preventDefault()
-
-  await reinstallEditor()
-}
-
 ipcRenderer.invoke('has-token-file')
   .then((hasTokenFile) => {
     if (hasTokenFile) {
@@ -139,7 +131,3 @@ document
 document
   .getElementById('update-editor')
   .addEventListener('click', onClickUpdateEditor)
-
-document
-  .getElementById('reinstall-editor')
-  .addEventListener('click', onClickReinstallEditor)

--- a/main.js
+++ b/main.js
@@ -83,7 +83,6 @@ const {
   confirmServiceIsRunning,
   install,
   updateEditor,
-  reinstallEditor,
   installEditor,
   installEditorDependencies,
   displayNotification,
@@ -137,8 +136,6 @@ ipcMain.on('go-to-create', goToCreate)
 ipcMain.on('go-to-index', goToIndex)
 
 ipcMain.answerRenderer('update-editor', updateEditor)
-
-ipcMain.answerRenderer('reinstall-editor', reinstallEditor)
 
 ipcMain.answerRenderer('install-editor', installEditor)
 

--- a/main.js
+++ b/main.js
@@ -476,7 +476,7 @@ ipcMain.answerRenderer('setServiceProperty', async ({ service, property, value }
 ipcMain.answerRenderer('getServices', () => services)
 
 {
-  const homeDir = path.join(ospath.home(), 'documents')
+  const homeDir = path.join(ospath.home(), 'Documents')
 
   const formBuilderPath = path.join(homeDir, 'formbuilder')
   app.paths.formbuilder = formBuilderPath

--- a/package-lock.json
+++ b/package-lock.json
@@ -12965,6 +12965,14 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "simple-git": {
+      "version": "1.132.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
+      "integrity": "sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==",
+      "requires": {
+        "debug": "^4.0.1"
+      }
+    },
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "sacred-fs": "^1.0.15",
     "selective-whitespace": "^1.0.4",
     "shelljs": "^0.8.3",
+    "simple-git": "^1.132.0",
     "strip-ansi": "^6.0.0",
     "yargs-parser": "^18.1.3"
   },

--- a/settings.html
+++ b/settings.html
@@ -229,12 +229,6 @@
                   class="govuk-link"
                   href="#"
                   id="update-editor">Update editor</a>
-                <p>
-                  <a
-                    class="govuk-link"
-                    href="#"
-                    id="reinstall-editor">Reinstall editor</a>
-                </p>
               </section>
             </div>
 

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -27,7 +27,6 @@ const {
   dismissNotification,
   executeInstallation,
   updateEditor,
-  reinstallEditor,
   installEditor,
   installEditorDependencies
 } = proxyquire('~/lib/main', {
@@ -82,8 +81,6 @@ describe('~/fb-editor-console-electron/lib/main', () => {
     it('exports the `executeInstallation` function', () => expect(executeInstallation).to.be.a('function'))
 
     it('exports the `updateEditor` function', () => expect(updateEditor).to.be.a('function'))
-
-    it('exports the `reinstallEditor` function', () => expect(reinstallEditor).to.be.a('function'))
 
     it('exports the `installEditor` function', () => expect(installEditor).to.be.a('function'))
 


### PR DESCRIPTION
# Installation bug

Installation of the editor has been failing for an unknown period
of time with the following errors:

```
renderer › The function requires a "fs" parameter but none was provided.
renderer › The function requires a "http" parameter but none was provided.
```

This was raised in [this issue](#207).

Despite those parameters being passed in the cloning still fails. After
some investigation I decided to just swap it out for something simpler as I was unable to ascertain specifically what `isomorphic-git` was failing to do.

# Updating the editor

The update function just pulled the lastest commits for the editor. What
we really want to happen is basically a full install.

Remove the reinstall editor and change the update editor to do a
reinstall instead.

As an aside, forcing the update process of the app to remove and then reinstall the app also helped to solve one potential reason why the editor hangs when starting some forms. The dependencies of the editor sometimes failed to be updated or installed but since the editor component had been correctly cloned the app would attempt to start it anyway.

# Tested

1. Reinstall from scratch
2. Update from within the app
3. Update from broken 0.5.40 from within the app

https://trello.com/c/f4uHLShM/436-investigate-fs-parameter-bug-in-electron-console-when-installing