### PR TITLE
Notify slack on failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
 
 jobs:
   lint_and_test:
@@ -15,6 +17,11 @@ jobs:
       - run:
           name: Test
           command: npm run test
+      - slack/status:
+          fail_only: true
+          only_for_branches: master
+          failure_message: ":facepalm:  Failed job $CIRCLE_JOB  :homer-disappear:"
+
 
 workflows:
   commit-workflow:


### PR DESCRIPTION
We want to notify slack when merges to master cause failures in the tests

https://trello.com/c/myuOzEs3/933-notify-slack-when-deployments-fail-succeed