### PR TITLE
Remove the word 'Console'

### DIFF
--- a/add.html
+++ b/add.html
@@ -92,7 +92,7 @@
 
         <div
           class="fb-editorheader--form xgovuk-header__link govuk-header__link--service-name">
-          Form Builder Console
+          Form Builder
         </div>
         <nav class="fb-editorheader--navigation">
           <ul>

--- a/create.html
+++ b/create.html
@@ -92,7 +92,7 @@
 
         <div
           class="fb-editorheader--form xgovuk-header__link govuk-header__link--service-name">
-          Form Builder Console
+          Form Builder
         </div>
         <nav class="fb-editorheader--navigation">
           <ul>

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
 
         <div
           class="fb-editorheader--form xgovuk-header__link govuk-header__link--service-name">
-          Form Builder Console
+          Form Builder
         </div>
         <nav class="fb-editorheader--navigation">
           <ul>

--- a/notification.html
+++ b/notification.html
@@ -13,7 +13,7 @@
     <div class="pane">
       <div class="pane--header">
         <h1 id="consoleInstallerTitle" class="govuk-heading-l">
-          Form Builder <span>Editor Console</span>
+          Form Builder <span>Editor</span>
         </h1>
       </div>
       <div class="pane--body">

--- a/password.html
+++ b/password.html
@@ -92,7 +92,7 @@
 
         <div
           class="fb-editorheader--form xgovuk-header__link govuk-header__link--service-name">
-          Form Builder Console
+          Form Builder
         </div>
         <nav class="fb-editorheader--navigation">
           <ul>

--- a/settings.html
+++ b/settings.html
@@ -92,7 +92,7 @@
 
         <div
           class="fb-editorheader--form xgovuk-header__link govuk-header__link--service-name">
-          Form Builder Console
+          Form Builder
         </div>
         <nav class="fb-editorheader--navigation">
           <ul>

--- a/token.html
+++ b/token.html
@@ -92,7 +92,7 @@
 
         <div
           class="fb-editorheader--form xgovuk-header__link govuk-header__link--service-name">
-          Form Builder Console
+          Form Builder
         </div>
         <nav class="fb-editorheader--navigation">
           <ul>


### PR DESCRIPTION
We want to have just 'Form Builder' as the name of the application, so remove all user facing instances of 'Console'.

## Before


<img width="603" alt="Screenshot 2020-09-18 at 17 54 19" src="https://user-images.githubusercontent.com/3466862/93624641-936f0480-f9d8-11ea-8a7e-75007c5cc3ed.png">

## After

<img width="503" alt="Screenshot 2020-09-18 at 17 54 37" src="https://user-images.githubusercontent.com/3466862/93624691-a5e93e00-f9d8-11ea-9c6d-7b24e8710489.png">

https://trello.com/c/nAEkQ7vK/935-navigation-content-changes-to-all-three-apps
