### PR TITLE
Updated the regex to accept the new github personal token format.

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -48,8 +48,7 @@ function hideError () {
 }
 
 // https://security.stackexchange.com/questions/215727/oauth-access-token-api-key-patterns-for-large-web-sites
-const isPersonalAccessTokenPattern = (value) => /[0-9a-fA-F]{40}/.test(value)
-
+const isPersonalAccessTokenPattern = (value) => /[0-9a-zA-Z_]{40}/.test(value)
 // at least eight characters of the printable ascii range
 const isAccessTokenPasswordPattern = (value) => /[ -~]{8,}/.test(value)
 


### PR DESCRIPTION
Github has changed the format of the token by adding an underscore, this failed the regex when adding to the editor.

Co-authored-by: Ian Anderson <ian.anderson@digital.justice.gov.uk>